### PR TITLE
CT-2794: Clicking on logout, user is not logged out instead spinner displayed indefinitely.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.m
@@ -129,7 +129,7 @@ static BOOL _sessionCookieManagementDisabled = NO;
 }
 
 + (NSArray<NSString *> *) domains {
-    return @[@".salesforce.com", @".force.com", @".cloudforce.com"];
+    return @[@".salesforce.com", @".force.com", @".cloudforce.com", @".site.com"];
 }
 
 + (void)resetSessionCookie


### PR DESCRIPTION
### Title

CT-2794: Clicking on logout, user is not logged out instead spinner displayed indefinitely.

## Summary

Added **Site** domain to clear the cookie upon logout